### PR TITLE
Implement the API-Key feature

### DIFF
--- a/_templates/command/new/view.ejs.t
+++ b/_templates/command/new/view.ejs.t
@@ -35,6 +35,6 @@ export default class View<%=Name%> extends View {
      */
     public sendFirstInteractionResponse(interaction: CommandInteraction) {
         const <%=h.changeCase.camel(name)%>Embed: MessageEmbed = this.getEmbed(EMBED_ID.<%=h.changeCase.constantCase(name)%>);
-        interaction.reply({ embeds: [<%=h.changeCase.camel(name)%>Embed] })
+        interaction.reply({ embeds: [<%=h.changeCase.camel(name)%>Embed] });
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
             - spotter-mongo:/data/db
         ports:
             - "27017:27017"
+        command: --quiet --logpath /dev/null # sweet silence
 
 networks:
     spotter-app-network:

--- a/src/Discord/Command/Commands.ts
+++ b/src/Discord/Command/Commands.ts
@@ -5,6 +5,7 @@ import DailiesController from "../Controller/Guildwars/DailiesController"
 import PingController from "../Controller/PingController";
 import PactSupplyController from "../Controller/Guildwars/PactSupplyController";
 import GuildStashController from "../Controller/Guildwars/GuildStashController";
+import ApiKeyController from "../Controller/Guildwars/ApiKeyController";
 
 /*
 Made like this, so discord api can chomp happily on the whole data object.
@@ -76,6 +77,38 @@ export const COMMANDS: DiscordCommandInterface[] = [
         },
         controller: new GuildStashController(),
     },
+    {
+        data: {
+            name: 'api-key',
+            description: "handles all GW-API key business",
+            options: [
+                {
+                    name: 'show',
+                    description: 'show all API keys associated with this Discord account',
+                    type: OPTION_TYPES.SUB_COMMAND
+                },
+                {
+                    name: 'add',
+                    description: 'add new GW_API key',
+                    type: OPTION_TYPES.SUB_COMMAND,
+                    options: [
+                        {
+                            name: 'api-key',
+                            description: "GW2 API key",
+                            type: OPTION_TYPES.STRING,
+                            required: true
+                        }
+                    ]
+                },
+                // {
+                //     name: 'remove',
+                //     description: 'remove specified GW_API key',
+                //     type: OPTION_TYPES.SUB_COMMAND
+                // },
+            ]
+        },
+        controller: new ApiKeyController(),
+    }, 
 ] // END_OF_COMMANDS (used to regex-match for scaffolding)
 
 // example of contents of options array - gives the person who invoked the cmd a required choice

--- a/src/Discord/Command/Commands.ts
+++ b/src/Discord/Command/Commands.ts
@@ -142,6 +142,19 @@ export const COMMANDS: DiscordCommandInterface[] = [
                             required: true
                         }
                     ]
+                },
+                {
+                    name: 'purge-all-data',
+                    description: "! WARNING ! - Deletes ALL data we have stored for you. This is irreversible.",
+                    type: OPTION_TYPES.SUB_COMMAND,
+                    options: [
+                        {
+                            name:'are-you-absolutely-sure',
+                            description: "Please type 'Yes, do as I say!', if you want to proceed with the purging process",
+                            type: OPTION_TYPES.STRING,
+                            required: true
+                        }
+                    ]
                 }
             ]
         },

--- a/src/Discord/Command/Commands.ts
+++ b/src/Discord/Command/Commands.ts
@@ -122,7 +122,7 @@ export const COMMANDS: DiscordCommandInterface[] = [
                             options: [
                                 {
                                     name: 'index',
-                                    description: "Specify the index of the key. If you want to see the list of indexed keys, use /api-key show",
+                                    description: "Specify the index of the key to delete. To show all your keys use /api-key show",
                                     type: OPTION_TYPES.NUMBER,
                                     required: true
                                 }
@@ -130,6 +130,19 @@ export const COMMANDS: DiscordCommandInterface[] = [
                         },
                     ]
                 },
+                {
+                    name: 'switch-preferred',
+                    description: "Switch your preferred key to a different API Key",
+                    type: OPTION_TYPES.SUB_COMMAND,
+                    options: [
+                        {
+                            name: 'index',
+                            description: "Specify the index of the key to switch to. To show all your keys use /api-key show",
+                            type: OPTION_TYPES.NUMBER,
+                            required: true
+                        }
+                    ]
+                }
             ]
         },
         controller: new ApiKeyController(),

--- a/src/Discord/Command/Commands.ts
+++ b/src/Discord/Command/Commands.ts
@@ -80,16 +80,16 @@ export const COMMANDS: DiscordCommandInterface[] = [
     {
         data: {
             name: 'api-key',
-            description: "handles all GW-API key business",
+            description: "Handles all GW2 API key business",
             options: [
                 {
                     name: 'show',
-                    description: 'show all API keys associated with this Discord account',
+                    description: 'Show all API keys associated with this Discord account',
                     type: OPTION_TYPES.SUB_COMMAND
                 },
                 {
                     name: 'add',
-                    description: 'add new GW_API key',
+                    description: 'Add new API key',
                     type: OPTION_TYPES.SUB_COMMAND,
                     options: [
                         {
@@ -100,11 +100,36 @@ export const COMMANDS: DiscordCommandInterface[] = [
                         }
                     ]
                 },
-                // {
-                //     name: 'remove',
-                //     description: 'remove specified GW_API key',
-                //     type: OPTION_TYPES.SUB_COMMAND
-                // },
+                {
+                    name: 'remove',
+                    description: "Remove specified API key(s)",
+                    type: OPTION_TYPES.SUB_COMMAND_GROUP,
+                    options: [
+                        {
+                            name: 'all',
+                            description: "Remove all your GW2 API keys",
+                            type: OPTION_TYPES.SUB_COMMAND
+                        },
+                        {
+                            name: 'non-preferred',
+                            description: "Remove all your non-preferred GW2 API keys",
+                            type: OPTION_TYPES.SUB_COMMAND
+                        },
+                        {
+                            name: 'by-index',
+                            description: "Remove single API key specified by index",
+                            type: OPTION_TYPES.SUB_COMMAND,
+                            options: [
+                                {
+                                    name: 'index',
+                                    description: "Specify the index of the key. If you want to see the list of indexed keys, use /api-key show",
+                                    type: OPTION_TYPES.NUMBER,
+                                    required: true
+                                }
+                            ]
+                        },
+                    ]
+                },
             ]
         },
         controller: new ApiKeyController(),

--- a/src/Discord/Controller/Guildwars/ApiKeyController.ts
+++ b/src/Discord/Controller/Guildwars/ApiKeyController.ts
@@ -27,7 +27,7 @@ export default class ApiKeyController implements DiscordControllerInterface {
             this.optarg = await this.handleAddAPIkey(userID, subCommand);
         }
 
-        const userInfo = <UserDB[]> await this.apiKeyApi.getUserInfoFromDB(userID);
+        const userInfo = <UserDB> await this.apiKeyApi.getUserInfoFromDB(userID);
         const view = new ViewApiKey(subCommand.name, userInfo, this.optarg);
         view.sendFirstInteractionResponse(interaction);
     }

--- a/src/Discord/Controller/Guildwars/ApiKeyController.ts
+++ b/src/Discord/Controller/Guildwars/ApiKeyController.ts
@@ -18,7 +18,8 @@ export default class ApiKeyController implements DiscordControllerInterface {
         this.handlers = {
             'add': this.handleAddAPIKey,
             'remove': this.handleRemoveAPIKey,
-            'switch-preferred': this.handleSwitchPreferredAPIKey
+            'switch-preferred': this.handleSwitchPreferredAPIKey,
+            'purge-all-data': this.handlePurgeAllUserData
         }
     }
 
@@ -71,9 +72,7 @@ export default class ApiKeyController implements DiscordControllerInterface {
         if (keysToRemove[0].startsWith('err')){return keysToRemove[0]}; // in case of error, "bubble up" the error message
 
         return await this.apiKeyApi.removeUserKeysFromDB(userID, keysToRemove);
-    }
-
-    
+    }    
 
     public handleSwitchPreferredAPIKey = async(userID: string, subCommand: CommandInteractionOption): Promise<string> => {
         const userInfo = <UserAPIKeyInfo> await this.apiKeyApi.getUserFromDB(userID);
@@ -87,4 +86,16 @@ export default class ApiKeyController implements DiscordControllerInterface {
         return await this.apiKeyApi.switchUserPreferredKeyInDB(userInfo, (<number> subCommand.options[0].value))
     }
 
+    public handlePurgeAllUserData = async(userID: string, subCommand: CommandInteractionOption): Promise<string> => {
+        const userInfo = <UserAPIKeyInfo> await this.apiKeyApi.getUserFromDB(userID);
+
+        if(!subCommand.options || !subCommand.options.length){return 'err-default'};
+        if(!userInfo){return 'err-no-user'};
+
+        const userAnswer = <string> subCommand.options[0].value;
+        const isUserSure = userAnswer === 'Yes, do as I say!';
+        if(! isUserSure) {return 'err-user-not-sure'};
+
+        return await this.apiKeyApi.purgeAllUserDataFromDB(userID);
+    }
 }

--- a/src/Discord/Controller/Guildwars/ApiKeyController.ts
+++ b/src/Discord/Controller/Guildwars/ApiKeyController.ts
@@ -14,7 +14,11 @@ export default class ApiKeyController implements DiscordControllerInterface {
 
     constructor() {
         this.apiKeyApi = new ApiKeyAPI();
-        this.optarg = '_';
+        /** return values of functions that interact with the APIs and DB are stored inside the optarg var
+         * so the View can choose which embed to send to the user
+         * without actually interacting with the DB or APIs directly in any way
+         * **/ 
+        this.optarg = '_'; 
         this.handlers = {
             'add': this.handleAddAPIKey,
             'remove': this.handleRemoveAPIKey,

--- a/src/Discord/Controller/Guildwars/ApiKeyController.ts
+++ b/src/Discord/Controller/Guildwars/ApiKeyController.ts
@@ -1,0 +1,41 @@
+import { CommandInteraction, CommandInteractionOption } from "discord.js";
+import DiscordControllerInterface from "../../../Model/Discord/DiscordControllerInterface";
+import ApiKeyAPI from "../../../Guildwars/ApiKey/ApiKeyAPI";
+import ViewApiKey from "../../View/ViewApiKey";
+import UserDB from "../../../Model/Guildwars/UserDB";
+
+
+export default class ApiKeyController implements DiscordControllerInterface {
+    private apiKeyApi: ApiKeyAPI;
+    optarg: string;
+
+    constructor() {
+        this.apiKeyApi = new ApiKeyAPI();
+        this.optarg = '_';
+    }
+
+    /**
+     * Handles discord interaction
+     * @param interaction 
+     */
+    public handleInteraction = async (interaction: CommandInteraction): Promise<void> => {
+        const subCommand = interaction.options.data[0];
+        const userID = interaction.user.id;
+        this.optarg = '_'; // need to reset optarg on each interaction
+
+        if (subCommand.name === 'add'){
+            this.optarg = await this.handleAddAPIkey(userID, subCommand);
+        }
+
+        const userInfo = <UserDB[]> await this.apiKeyApi.getUserInfoFromDB(userID);
+        const view = new ViewApiKey(subCommand.name, userInfo, this.optarg);
+        view.sendFirstInteractionResponse(interaction);
+    }
+
+    public handleAddAPIkey = async(userID:string, subCommand: CommandInteractionOption): Promise<string> => {
+        if(!subCommand.options || !subCommand.options.length){return 'err-default'}; // "should" never get in here
+        const APIkey = <string> subCommand.options[0].value;
+        
+        return await this.apiKeyApi.addAPIKeyToDB(userID, APIkey);
+    }
+}

--- a/src/Discord/Controller/Guildwars/ApiKeyController.ts
+++ b/src/Discord/Controller/Guildwars/ApiKeyController.ts
@@ -2,9 +2,9 @@ import { CommandInteraction, CommandInteractionOption } from "discord.js";
 import DiscordControllerInterface from "../../../Model/Discord/DiscordControllerInterface";
 import ApiKeyAPI from "../../../Guildwars/ApiKey/ApiKeyAPI";
 import ViewApiKey from "../../View/ViewApiKey";
-import UserDB from "../../../Model/Guildwars/UserDB";
 import APIKeyInfo from "../../../Model/Guildwars/APIKeyInfo";
 import EMOJIS from "../../View/enum/EMOJIS";
+import UserAPIKeyInfo from "../../../Model/Guildwars/UserAPIKeyInfo";
 
 
 export default class ApiKeyController implements DiscordControllerInterface {
@@ -32,10 +32,14 @@ export default class ApiKeyController implements DiscordControllerInterface {
             this.optarg = await this.handleAddAPIkey(userID, subCommand);
         }
 
-        const userDB = await this.apiKeyApi.getUserFromDB(userID);
-        const userKeys: APIKeyInfo[] | undefined = userDB ? await this.apiKeyApi.createAPIKeysInfo(<UserDB> userDB) : undefined;
+        let userDB = <UserAPIKeyInfo | undefined> await this.apiKeyApi.getUserFromDB(userID);
 
-        const view = new ViewApiKey(subCommand.name, userKeys, this.optarg);
+        // it validates all keys on show command
+        if (subCommand.name === 'show'){
+            userDB = await this.apiKeyApi.validateAPIKeys(userDB);
+        }
+
+        const view = new ViewApiKey(subCommand.name, userDB, this.optarg);
         view.sendFirstInteractionResponse(interaction);
     }
 

--- a/src/Discord/View/View.ts
+++ b/src/Discord/View/View.ts
@@ -2,6 +2,7 @@ import { ColorResolvable, MessageActionRow, MessageButton, MessageButtonStyleRes
 import ViewDefault from "../../Model/Discord/ViewDefault";
 import { THUMBNAILS } from "./enum/THUMBNAILS";
 import { v4 as uuidv4 } from 'uuid';
+import { EMBED_COLORS } from "./enum/EMBED_COLORS";
 
 /**
  * Acts as a base class for all views
@@ -10,7 +11,7 @@ export default class View implements ViewDefault {
     defaultColor: number;
     defaultTitle: string;
     defaultThumbnail: string;
-    //This allows us to have ONE view with MULTIPLE embeds and buttons without code magic. Yay!
+    // This allows us to have ONE view with MULTIPLE embeds and buttons without code magic. Yay!
     embeds: Map<string, MessageEmbed>;
     actionRows: Map<string, MessageActionRow[]>;
     //
@@ -20,9 +21,9 @@ export default class View implements ViewDefault {
      * @param seed - uses v4 uuid
      */
     constructor(seed: string = uuidv4()) {
-        this.defaultColor = 0xBAD4A1;
+        this.defaultColor = EMBED_COLORS.DEFAULT;
         this.defaultTitle = "default title";
-        this.defaultThumbnail = THUMBNAILS.DEFAULT;
+        this.defaultThumbnail = ''; // THUMBNAILS.DEFAULT
         this.embeds = new Map<string, MessageEmbed>();
         this.actionRows = new Map<string, MessageActionRow[]>();
         this.seed = seed;

--- a/src/Discord/View/ViewApiKey.ts
+++ b/src/Discord/View/ViewApiKey.ts
@@ -5,11 +5,13 @@ import { EMBED_ID } from "./enum/EMBED_ID";
 import EMOJIS from "./enum/EMOJIS";
 import { EMBED_COLORS } from "./enum/EMBED_COLORS";
 import APIKeyInfo from "../../Model/Guildwars/APIKeyInfo";
+import UserAPIKeyInfo from "../../Model/Guildwars/UserAPIKeyInfo";
 
 
 export default class ViewApiKey extends View {
     commandName: string;
     userKeys: APIKeyInfo[] | undefined;
+    preferredKeyIndex: number | undefined;
     embedSetters: Record<string, (embed: MessageEmbed) => Promise<ViewApiKey>>;
     neededPermissions: string[] = ['account'];
     // could maybe be inside its own file
@@ -37,10 +39,11 @@ export default class ViewApiKey extends View {
      * @param userInfos 
      * @param optarg - can store things like api key to add or the index of the to-be-removed api key
     */
-    public constructor(commandName: string, userKeys: APIKeyInfo[] | undefined, optarg: string) {
+    public constructor(commandName: string, userKeysInfo: UserAPIKeyInfo | undefined, optarg: string) {
         super();
         this.commandName = commandName;
-        this.userKeys = userKeys;
+        this.userKeys = userKeysInfo ? userKeysInfo.api_keys : undefined;
+        this.preferredKeyIndex = userKeysInfo ? userKeysInfo.preferred_key_index : undefined;
         this.embedSetters = {
             'show': this.setEmbedKeyShow,
             'add': this.setEmbedKeyAdd,
@@ -94,10 +97,10 @@ export default class ViewApiKey extends View {
             for (let index = 0; index < this.userKeys.length; index++){
                 const userKey = this.userKeys[index];
                 const isValidEmoji = userKey.is_valid ? ':white_check_mark:' : ':x:';
-                const isPreferredEmoji = userKey.is_preferred ? ':sunny:' : ':cloud:'; // Pretty symbolic, I guess
+                const isPreferredEmoji = this.preferredKeyIndex === index ? ':sunny:' : ':cloud:'; // Pretty symbolic, I guess
                 const prettyPerms = `:lock: \`${userKey.key_permissions.map(perm => perm.toUpperCase()).join('\`, \`')}\``;
 
-                embed.addField(`${isPreferredEmoji} ${userKey.account_name} - ${userKey.key_name}`, `${isValidEmoji} \`${userKey.key_id}\`\n${prettyPerms}`);
+                embed.addField(`${isPreferredEmoji} ${userKey.account_name} - ${userKey.key_name}`, `${isValidEmoji} ||${userKey.key_id}||\n${prettyPerms}`);
             }
             
         }
@@ -109,7 +112,7 @@ export default class ViewApiKey extends View {
         if (! this.userKeys) {return this}; // "should" never happen
         const lastKey = this.userKeys[this.userKeys.length - 1];
 
-        embed.addField(':white_check_mark: Success!', `The API Key \`${lastKey.key_id}\` is valid and ready to go. You can use it right away!`);
+        embed.addField(':white_check_mark: Success!', `The API Key ||${lastKey.key_id}|| is valid and ready to go. You can use it right away!`);
         return this;
     }
 

--- a/src/Discord/View/ViewApiKey.ts
+++ b/src/Discord/View/ViewApiKey.ts
@@ -11,7 +11,7 @@ import UserAPIKeyInfo from "../../Model/Guildwars/UserAPIKeyInfo";
 export default class ViewApiKey extends View {
     commandName: string;
     userKeys: APIKeyInfo[] | undefined;
-    preferredKeyIndex: number | undefined;
+    preferredKey: string | undefined;
     embedSetters: Record<string, (embed: MessageEmbed) => Promise<ViewApiKey>>;
     neededPermissions: string[] = ['account'];
     // could maybe be inside its own file
@@ -43,7 +43,7 @@ export default class ViewApiKey extends View {
         super();
         this.commandName = commandName;
         this.userKeys = userKeysInfo ? userKeysInfo.api_keys : undefined;
-        this.preferredKeyIndex = userKeysInfo ? userKeysInfo.preferred_key_index : undefined;
+        this.preferredKey = userKeysInfo ? userKeysInfo.preferred_api_key : undefined;
         this.embedSetters = {
             'show': this.setEmbedKeyShow,
             'add': this.setEmbedKeyAdd,
@@ -97,7 +97,7 @@ export default class ViewApiKey extends View {
             for (let index = 0; index < this.userKeys.length; index++){
                 const userKey = this.userKeys[index];
                 const isValidEmoji = userKey.is_valid ? ':white_check_mark:' : ':x:';
-                const isPreferredEmoji = this.preferredKeyIndex === index ? ':sunny:' : ':cloud:'; // Pretty symbolic, I guess
+                const isPreferredEmoji = userKey.key_id === this.preferredKey ? ':sunny:' : ':cloud:'; // Pretty symbolic, I guess
                 const prettyPerms = `:lock: \`${userKey.key_permissions.map(perm => perm.toUpperCase()).join('\`, \`')}\``;
 
                 embed.addField(`${isPreferredEmoji} ${userKey.account_name} - ${userKey.key_name}`, `${isValidEmoji} ||${userKey.key_id}||\n${prettyPerms}`);

--- a/src/Discord/View/ViewApiKey.ts
+++ b/src/Discord/View/ViewApiKey.ts
@@ -32,7 +32,8 @@ export default class ViewApiKey extends View {
         this.embedSetters = {
             'show': this.setEmbedKeyShow,
             'add': this.setEmbedKeyAdd,
-            'remove': this.setEmbedKeyRemove
+            'remove': this.setEmbedKeyRemove,
+            'switch-preferred': this.setEmbedKeySwitchPreferred
         }
 
         this.setEmbeds();
@@ -113,6 +114,19 @@ export default class ViewApiKey extends View {
         const countRemoved = ~~this.optarg.split('-')[1];
 
         embed.addField(`:white_check_mark: Success!`, `${EMOJIS['Bin']} Removed ${countRemoved} GW2 API Key${countRemoved === 1 ? '' : 's'}.`);
+        
+        return this;
+    }
+
+    private setEmbedKeySwitchPreferred = async(embed: MessageEmbed): Promise<ViewApiKey> => {
+        const keyObj = this.userKeys?.find(key => key.key_id === this.preferredKey);
+        
+        const lines = [
+            `Your preferred API Key is now **${keyObj?.account_name} - ${keyObj?.key_name}.**`,
+            `Any commands that need GW2 API Key will now use this key.`,            
+        ]
+
+        embed.addField(`:white_check_mark: Success!`, lines.join('\n'));
         
         return this;
     }

--- a/src/Discord/View/ViewApiKey.ts
+++ b/src/Discord/View/ViewApiKey.ts
@@ -33,7 +33,8 @@ export default class ViewApiKey extends View {
             'show': this.setEmbedKeyShow,
             'add': this.setEmbedKeyAdd,
             'remove': this.setEmbedKeyRemove,
-            'switch-preferred': this.setEmbedKeySwitchPreferred
+            'switch-preferred': this.setEmbedKeySwitchPreferred,
+            'purge-all-data': this.setEmbedPurgeAllData
         }
 
         this.setEmbeds();
@@ -127,6 +128,14 @@ export default class ViewApiKey extends View {
         ]
 
         embed.addField(`:white_check_mark: Success!`, lines.join('\n'));
+        
+        return this;
+    }
+
+    private setEmbedPurgeAllData = async(embed: MessageEmbed): Promise<ViewApiKey> => {
+        embed.setColor(EMBED_COLORS.SILENT);
+
+        embed.addField(`${EMOJIS['Bin']} Success!`, `All your data that you have stored with us was purged.`);
         
         return this;
     }

--- a/src/Discord/View/ViewApiKey.ts
+++ b/src/Discord/View/ViewApiKey.ts
@@ -1,0 +1,124 @@
+import { CommandInteraction, EmbedField, MessageEmbed } from "discord.js";
+import View from "./View";
+import { THUMBNAILS } from "./enum/THUMBNAILS";
+import { EMBED_ID } from "./enum/EMBED_ID";
+import EMOJIS from "./enum/EMOJIS";
+import UserDB from "../../Model/Guildwars/UserDB";
+import { EMBED_COLORS } from "./enum/EMBED_COLORS";
+
+
+export default class ViewApiKey extends View {
+    commandName: string;
+    userInfos: UserDB[];
+    embedSetters: Record<string, (embed: MessageEmbed) => Promise<ViewApiKey>>;
+    neededPermissions: string[] = ['account'];
+    // could maybe be inside its own file
+    errorFields: Record<string, EmbedField> = {
+        'err-default': {
+            name: 'Something went wrong',
+            value: 'Lumberjack Jack has some work to do.', 
+            inline: false
+        },
+        'err-invalid-api-key': {
+            name: 'Invalid GW2 API Key', 
+            value: 'Please provide a valid GW2 API Key.', 
+            inline: false
+        },
+        'err-non-unique-key': {
+            name: 'Non-unique GW2 API Key',
+            value: 'You cannot add the same key twice.',
+            inline: false
+        }
+    }
+
+    /**
+     * 
+     * @param commandName 
+     * @param userInfos 
+     * @param optarg - can store things like api key to add or the index of the to-be-removed api key
+    */
+    public constructor(commandName: string, userInfos: UserDB[], optarg: string) {
+        super();
+        this.commandName = commandName;
+        this.userInfos = userInfos;
+        this.embedSetters = {
+            'show': this.setEmbedKeyShow,
+            'add': this.setEmbedKeyAdd,
+        }
+
+        this.setEmbeds(optarg);
+    }
+
+    /**
+     * Sets embeds
+     */
+    public setEmbeds = async (optarg: string): Promise<ViewApiKey> => {
+        const apiKeyEmbed = this.createEmbed(`${EMBED_ID.API_KEY}-${this.commandName}`, `Guild Wars 2 API Key Settings`);
+
+        // 'err' is consistent for all subcommands so this handles displayal of all errors the user should see
+        if (optarg.includes('err')){
+            const errorField = this.errorFields[optarg];
+
+            apiKeyEmbed.color = EMBED_COLORS.ERROR;
+            apiKeyEmbed.addField(`Error: ${errorField.name}`, errorField.value, errorField.inline);
+          
+            return this;
+        }
+
+        await this.embedSetters[this.commandName](apiKeyEmbed);
+        return this;
+    }
+
+    /**
+     * To handle the "show" subcommand's views
+     * @param embed 
+     * @returns 
+    */
+    private setEmbedKeyShow = async(embed: MessageEmbed): Promise<ViewApiKey> => {
+        // user is not in our DB or hasn't added any key yet
+        if (!this.userInfos || this.userInfos.length === 0 || this.userInfos[0].API_Keys.length === 0){
+            const lines = [
+                "No worries though, you can use: **/api-key add <YOUR-API-KEY>** to add a new key.",
+                `The API key should have at least the following permissions: \`${this.neededPermissions.join('\`, \`')}\``,
+                "*You can create a new API key [here](https://account.arena.net/applications).*",
+            ]
+
+            embed.addField("I don't know any of your GW2 API keys", lines.join('\n'));
+        }
+        // means we have the user in the DB, and have at least one api key stored for them
+        else {
+            const userInfo = this.userInfos[0];
+            embed.addField(':closed_lock_with_key: Your GW2 API Keys', `If you'd like to add another one, use **/api-key add**.`);
+
+            for (let index = 0; index < userInfo.API_Keys.length; index++){
+                const isPreferredKey = index === userInfo.preferredAPIKey;
+                const emojiStatus = isPreferredKey ? ':sunny:' : ':cloud:'; // Pretty symbolic, I guess
+
+                embed.addField(`${emojiStatus} DefaultUser.1234 - DefaultAPIKeyName`, `:white_check_mark: \`${userInfo.API_Keys[index]}\``)
+            }
+            
+        }
+        
+        return this;
+    }
+
+    private setEmbedKeyAdd = async(embed: MessageEmbed): Promise<ViewApiKey> => {
+        const userKeys = this.userInfos[0]?.API_Keys;
+        const lastKey = userKeys[userKeys.length - 1];
+
+        embed.addField(':white_check_mark: Success!', `The API Key \`${lastKey}\` is valid and ready to go. You can use it right away!`);
+        return this;
+    }
+
+
+    /**
+     * Returns first interaction response
+     * @param interaction 
+     */
+    public sendFirstInteractionResponse(interaction: CommandInteraction) {
+        const apiKeyEmbed: MessageEmbed = this.getEmbed(`${EMBED_ID.API_KEY}-${this.commandName}`);
+
+        interaction.user.send({ embeds: [apiKeyEmbed] });
+        interaction.reply(`${EMOJIS['SpotterMail']} Answered your command as a private message.`);
+    }
+}

--- a/src/Discord/View/ViewApiKey.ts
+++ b/src/Discord/View/ViewApiKey.ts
@@ -41,7 +41,8 @@ export default class ViewApiKey extends View {
     }
 
     /**
-     * Sets embeds
+     * Decides which embedSetter to use based on the subcommandName
+     * In case of errors, handles error messages the user sees
      */
     public setEmbeds = async (): Promise<ViewApiKey> => {
         const apiKeyEmbed = this.createEmbed(`${EMBED_ID.API_KEY}-${this.commandName}`, `Guild Wars 2 API Key Settings`);

--- a/src/Discord/View/enum/EMBED_COLORS.ts
+++ b/src/Discord/View/enum/EMBED_COLORS.ts
@@ -1,0 +1,10 @@
+/**
+ * Mooooore enums
+ */
+export enum EMBED_COLORS {
+    DEFAULT = 0xBAD4A1,
+    ERROR = 0xD17B88,
+    IMPORTANT = 0x78A1BB,
+    GOLD = 0xA37C40,
+    SILENT = 0x59594A
+}

--- a/src/Discord/View/enum/EMBED_ID.ts
+++ b/src/Discord/View/enum/EMBED_ID.ts
@@ -6,4 +6,5 @@ export enum EMBED_ID {
     DAILIES = "dailies",
     PACT_SUPPLY = "pact-supply",
     GUILD_STASH = "guild-stash",
+    API_KEY = "api-key",
 }

--- a/src/Discord/View/enum/EMOJIS.ts
+++ b/src/Discord/View/enum/EMOJIS.ts
@@ -20,6 +20,7 @@ const EMOJIS: Record<string, string> = {
     'Boss': "<:event_boss:894990815443714109>",
     'PSNA': "<:psna:896816322581774357>",
     'BadgeOfHonor': "<:badge_of_honor:897531055303704587>",
+    'SpotterMail': "<:spotter_mail:910594701718065264>",
 }
 
 export default EMOJIS;

--- a/src/Discord/View/enum/EMOJIS.ts
+++ b/src/Discord/View/enum/EMOJIS.ts
@@ -21,6 +21,7 @@ const EMOJIS: Record<string, string> = {
     'PSNA': "<:psna:896816322581774357>",
     'BadgeOfHonor': "<:badge_of_honor:897531055303704587>",
     'SpotterMail': "<:spotter_mail:910594701718065264>",
+    'Bin': "<:bin:912181085872488456>"
 }
 
 export default EMOJIS;

--- a/src/Discord/View/enum/ERROR_FIELDS.ts
+++ b/src/Discord/View/enum/ERROR_FIELDS.ts
@@ -18,7 +18,7 @@ const ERROR_FIELDS: Record<string, EmbedField> = {
     },
     'err-no-api-keys': {
         name: 'No GW2 API keys to remove',
-        value: 'I either do not have any of your keys stored, or there are no keys matching your removal-criteria.',
+        value: 'I either do not have any of your keys stored, or there are no keys matching your criteria.',
         inline: false
     },
     'err-no-user': {
@@ -34,6 +34,11 @@ const ERROR_FIELDS: Record<string, EmbedField> = {
     'err-remove-preferred': {
         name: 'Cannot remove your preferred API Key',
         value: 'If you want to delete your preferred key, you can either switch to another key first, or remove all keys.',
+        inline: false
+    },
+    'err-already-preferred': {
+        name: 'This API Key is already your prefered key',
+        value: 'You can switch to any non-preferred key.\nUse **/api-key show** for the list of all your keys.',
         inline: false
     }
 }

--- a/src/Discord/View/enum/ERROR_FIELDS.ts
+++ b/src/Discord/View/enum/ERROR_FIELDS.ts
@@ -13,7 +13,7 @@ const ERROR_FIELDS: Record<string, EmbedField> = {
     },
     'err-non-unique-key': {
         name: 'Non-unique GW2 API Key',
-        value: 'You cannot add the same key twice.',
+        value: 'You cannot add the same API Key twice.',
         inline: false
     },
     'err-no-api-keys': {
@@ -22,7 +22,7 @@ const ERROR_FIELDS: Record<string, EmbedField> = {
         inline: false
     },
     'err-no-user': {
-        name: 'No data asocciated with you',
+        name: 'No data asocciated with this account',
         value: 'I do not have you in my archives.',
         inline: false
     },
@@ -37,8 +37,8 @@ const ERROR_FIELDS: Record<string, EmbedField> = {
         inline: false
     },
     'err-already-preferred': {
-        name: 'This API Key is already your prefered key',
-        value: 'You can switch to any non-preferred key.\nUse **/api-key show** for the list of all your keys.',
+        name: 'This API Key is already your preferred key',
+        value: 'You can only switch to any non-preferred key.\nUse **/api-key show** for the list of all your keys.',
         inline: false
     },
     'err-user-not-sure': {

--- a/src/Discord/View/enum/ERROR_FIELDS.ts
+++ b/src/Discord/View/enum/ERROR_FIELDS.ts
@@ -40,6 +40,11 @@ const ERROR_FIELDS: Record<string, EmbedField> = {
         name: 'This API Key is already your prefered key',
         value: 'You can switch to any non-preferred key.\nUse **/api-key show** for the list of all your keys.',
         inline: false
+    },
+    'err-user-not-sure': {
+        name: 'Incorrect purge check answer',
+        value: `You have to type exactly '**Yes, do as I say!**' (without quotes) to succesfully purge.`,
+        inline: false
     }
 }
 

--- a/src/Discord/View/enum/ERROR_FIELDS.ts
+++ b/src/Discord/View/enum/ERROR_FIELDS.ts
@@ -1,0 +1,41 @@
+import { EmbedField } from "discord.js";
+
+const ERROR_FIELDS: Record<string, EmbedField> = {
+    'err-default': {
+        name: 'Something went wrong',
+        value: 'Lumberjack Jack has some work to do.', 
+        inline: false
+    },
+    'err-invalid-api-key': {
+        name: 'Invalid GW2 API Key', 
+        value: 'Please provide a valid GW2 API Key.', 
+        inline: false
+    },
+    'err-non-unique-key': {
+        name: 'Non-unique GW2 API Key',
+        value: 'You cannot add the same key twice.',
+        inline: false
+    },
+    'err-no-api-keys': {
+        name: 'No GW2 API keys to remove',
+        value: 'I either do not have any of your keys stored, or there are no keys matching your removal-criteria.',
+        inline: false
+    },
+    'err-no-user': {
+        name: 'No data asocciated with you',
+        value: 'I do not have you in my archives.',
+        inline: false
+    },
+    'err-wrong-key-index': {
+        name: 'Wrong API Key Index',
+        value: 'There is no API key with this index.\nYou can use **/api-key show** for the list of all your keys.',
+        inline: false
+    },
+    'err-remove-preferred': {
+        name: 'Cannot remove your preferred API Key',
+        value: 'If you want to delete your preferred key, you can either switch to another key first, or remove all keys.',
+        inline: false
+    }
+}
+
+export default ERROR_FIELDS;

--- a/src/Guildwars/ApiKey/ApiKeyAPI.ts
+++ b/src/Guildwars/ApiKey/ApiKeyAPI.ts
@@ -50,7 +50,7 @@ export default class ApiKeyAPI {
         const userSkeleton: UserAPIKeyInfo = {
             _id: userID,
             api_keys: [],
-            preferred_key_index: -1
+            preferred_api_key: ""
         }
     
         await insertOne(userSkeleton, collection);
@@ -83,7 +83,7 @@ export default class ApiKeyAPI {
 
         return <UserAPIKeyInfo> {
             _id: userInfo._id,
-            preferred_key_index: userInfo.preferred_key_index,
+            preferred_api_key: userInfo.preferred_api_key,
             api_keys: updatedKeys
         };
     }
@@ -129,13 +129,11 @@ export default class ApiKeyAPI {
         // check if the new api key is unique
         if (userDBNew.api_keys.some(key => key.key_id === APIKey)){return 'err-non-unique-key'}
 
-        // Push the new key to the API_Keys array, and set the preferred key to be the one we just pushed
-        const lastIndex = userDBNew.api_keys.length;
-
         // need to transform apikey to the obj
         const apiKeyInfo = await this.getValidAPIKeyInfo(APIKey);
 
-        await collection.updateOne({_id: userID}, {$set: {preferred_key_index: lastIndex}, $push: {api_keys: apiKeyInfo}});
+        // Push the new key to the API_Keys array, and set the preferred key to be the one we just added
+        await collection.updateOne({_id: userID}, {$set: {preferred_api_key: APIKey}, $push: {api_keys: apiKeyInfo}});
         return 'success';
     }
 

--- a/src/Guildwars/ApiKey/ApiKeyAPI.ts
+++ b/src/Guildwars/ApiKey/ApiKeyAPI.ts
@@ -1,0 +1,88 @@
+import axios from "axios"
+import { Collection, Document } from "mongodb";
+import UserDB from "../../Model/Guildwars/UserDB";
+import { collectionExists, getCollection, getDb, insertMany, insertOne } from "../../Mongo/Mongo";
+import { GW_API_URL } from "../General/enum/GW_API_URL";
+
+
+export default class ApiKeyAPI {
+
+    /**
+     * Returns either [] if the user is not our DB
+     * or an array of one Document if the user is found since _id is unique
+     * 
+    */    
+    public getUserInfoFromDB = async (userID: string) => {
+        const collection = await getCollection('users');
+        const userInfo = await collection?.find({_id: userID}).toArray();
+        return userInfo ? userInfo : [];
+    }
+
+    /** 
+     * Or rather add the default skeleton of an user object
+    */
+    public addUserToCollection = async (userID: string, collection: Collection<Document>) => {
+        const userDefault: UserDB = {
+            _id: userID,
+            API_Keys: [],
+            preferredAPIKey: -1
+        }
+        
+        await insertOne(userDefault, collection);
+    }
+
+    /**
+     * Axios errors out with 401 if the key is invalid
+     * @param APIKey 
+     * @returns 
+     */
+    public isAPIKeyValid = async (APIKey: string) => {
+        try {
+            await axios.get(`${GW_API_URL.TOKENINFO}?access_token=${APIKey}`);
+        }
+        catch {
+            return false;
+        }
+        return true;
+    }
+
+    
+    /**
+     * adds new API key for the specified user
+     * should replace those returns with an enum prolly
+     * @param userID
+     * @param APIKey 
+     */
+    public addAPIKeyToDB = async (userID: string, APIKey: string) => {
+        const collection = await getCollection('users');
+        if(!collection) {return 'err-default'}; // Ahhhh
+
+        const userInfo = <UserDB[]> await this.getUserInfoFromDB(userID);
+        
+        // validate key here first
+        if (! await this.isAPIKeyValid(APIKey)) {return 'err-invalid-api-key'}
+
+        // if the user is not in our DB, add their default skeleton object
+        if (! userInfo || userInfo.length === 0){
+            await this.addUserToCollection(userID, collection);
+        }
+
+        // unless the insert failed, user has to be in the DB
+        const userInfoNew = <UserDB[]> await this.getUserInfoFromDB(userID);
+
+        // check if the new api key is unique
+        if (userInfoNew[0].API_Keys.includes(APIKey)){return 'err-non-unique-key'}
+
+        // Push the new key to the API_Keys array, and set the preferred key to be the one we just pushed
+        const lastIndex = userInfoNew[0].API_Keys.length;
+        await collection.updateOne({_id: userID}, {$set: {preferredAPIKey: lastIndex}, $push: {API_Keys: APIKey}});
+        return 'success';
+    }
+
+
+
+    // removeAPIKey
+    // changepreferredAPIKeyToUse
+    
+}
+

--- a/src/Guildwars/ApiKey/ApiKeyAPI.ts
+++ b/src/Guildwars/ApiKey/ApiKeyAPI.ts
@@ -3,7 +3,7 @@ import { Collection, Document } from "mongodb";
 import AccountInfo from "../../Model/Guildwars/AccountInfo";
 import APIKeyInfo from "../../Model/Guildwars/APIKeyInfo";
 import TokenInfo from "../../Model/Guildwars/TokenInfo";
-import UserDB from "../../Model/Guildwars/UserDB";
+import UserAPIKeyInfo from "../../Model/Guildwars/UserAPIKeyInfo";
 import { collectionExists, getCollection, getDb, insertMany, insertOne } from "../../Mongo/Mongo";
 import { GW_API_URL } from "../General/enum/GW_API_URL";
 
@@ -18,7 +18,6 @@ export default class ApiKeyAPI {
         const userInfo = await collection?.findOne({_id: userID});
         return userInfo;
     }
-
     
     public getAPIKeyTokenInfo = async(APIKey: string) => {
         const keyResponse = await axios.get(`${GW_API_URL.TOKENINFO}?access_token=${APIKey}`);
@@ -29,61 +28,6 @@ export default class ApiKeyAPI {
         const accountResponse = await axios.get(`${GW_API_URL.ACCOUNT}?access_token=${APIKey}`);
         const accountInfo: AccountInfo = accountResponse.data;
         return accountInfo.name;
-    }
-
-    /**
-     * Need to check API Keys validity before displaying something
-     */
-    public getAPIKeyInfo = async(APIKey: string, isPreferred: boolean = false) => {
-        const isValid = await this.isAPIKeyValid(APIKey);
-        
-        if (!isValid) {
-           return <APIKeyInfo> {
-                account_name: '?',
-                key_id: APIKey,
-                key_name: 'Invalid API Key',
-                key_permissions: [],
-                is_valid: false,
-                is_preferred: isPreferred
-            }
-        }
-
-        const accountName = await this.getAccountName(APIKey);
-        const keyTokenInfo = await this.getAPIKeyTokenInfo(APIKey);        
-
-        return <APIKeyInfo> {
-            account_name: accountName,
-            key_id: APIKey,
-            key_name: keyTokenInfo.name,
-            key_permissions: keyTokenInfo.permissions,
-            is_valid: isValid,
-            is_preferred: isPreferred
-        }
-    }
-
-    /**
-     * Creates an array of all the juicy APIKey data
-     * assumes user actually exists!
-     */
-    public createAPIKeysInfo = async(userDB: UserDB) => {
-        return await Promise.all(userDB.API_Keys.map( async (key, index) => {
-            const isPreferred = index === userDB.preferredAPIKey;
-            return await this.getAPIKeyInfo(key, isPreferred);
-        }));
-    }
-
-
-    /** 
-     * Or rather add the default skeleton of an user object
-    */
-    public addUserToCollection = async (userID: string, collection: Collection<Document>) => {
-        const userDefault: UserDB = {
-            _id: userID,
-            API_Keys: [],
-            preferredAPIKey: -1
-        }
-        
-        await insertOne(userDefault, collection);
     }
 
     /**
@@ -101,36 +45,97 @@ export default class ApiKeyAPI {
         return true;
     }
 
+
+    public insertDefaultUserSkeleton = async (userID: string, collection: Collection<Document>) => {
+        const userSkeleton: UserAPIKeyInfo = {
+            _id: userID,
+            api_keys: [],
+            preferred_key_index: -1
+        }
+    
+        await insertOne(userSkeleton, collection);
+    }
+
+    /**
+     * Replaces the original array with a validated one
+     * i.e. if the key is valid it just copies the original
+     * if the key is now invalid, it uses the invalidKeySkeleton
+     * @param userInfo 
+     * @returns 
+     */
+    public validateAPIKeys = async (userInfo: UserAPIKeyInfo | undefined) => {
+        if (! userInfo) {return undefined};
+        
+        const invalidKeySkeleton = (APIKey: string) => {
+            return <APIKeyInfo> {
+                account_name: '?',
+                key_id: APIKey,
+                key_name: 'Invalid API Key',
+                key_permissions: [],
+                is_valid: false,
+            }
+        }
+
+        const updatedKeys = await Promise.all(userInfo.api_keys.map(async key => {
+            const isValid = await this.isAPIKeyValid(key.key_id);
+            return isValid ? key : invalidKeySkeleton(key.key_id);
+        }));
+
+        return <UserAPIKeyInfo> {
+            _id: userInfo._id,
+            preferred_key_index: userInfo.preferred_key_index,
+            api_keys: updatedKeys
+        };
+    }
+
+    /**
+     * ! Assumes the key is valid
+     */
+    public getValidAPIKeyInfo = async (APIKey: string) => {
+        const accountName = await this.getAccountName(APIKey);
+        const keyTokenInfo = await this.getAPIKeyTokenInfo(APIKey);        
+
+        return <APIKeyInfo> {
+            account_name: accountName,
+            key_id: APIKey,
+            key_name: keyTokenInfo.name,
+            key_permissions: keyTokenInfo.permissions,
+            is_valid: true,
+        }
+    }
     
     /**
      * adds new API key for the specified user
-     * should replace those returns with an enum prolly
      * @param userID
      * @param APIKey 
      */
     public addAPIKeyToDB = async (userID: string, APIKey: string) => {
         const collection = await getCollection('users');
         if(!collection) {return 'err-default'}; // Ahhhh
-
-        const userDB = <UserDB> await this.getUserFromDB(userID);
         
         // validate key here first
         if (! await this.isAPIKeyValid(APIKey)) {return 'err-invalid-api-key'}
 
+        const userDB = <UserAPIKeyInfo> await this.getUserFromDB(userID);
+
         // if the user is not in our DB, add their default skeleton object
         if (! userDB){
-            await this.addUserToCollection(userID, collection);
+            await this.insertDefaultUserSkeleton(userID, collection);
         }
 
         // unless the insert failed, user has to be in the DB
-        const userDBNew = <UserDB> await this.getUserFromDB(userID);
+        const userDBNew = <UserAPIKeyInfo> await this.getUserFromDB(userID);
 
         // check if the new api key is unique
-        if (userDBNew.API_Keys.includes(APIKey)){return 'err-non-unique-key'}
+        if (userDBNew.api_keys.some(key => key.key_id === APIKey)){return 'err-non-unique-key'}
 
         // Push the new key to the API_Keys array, and set the preferred key to be the one we just pushed
-        const lastIndex = userDBNew.API_Keys.length;
-        await collection.updateOne({_id: userID}, {$set: {preferredAPIKey: lastIndex}, $push: {API_Keys: APIKey}});
+        const lastIndex = userDBNew.api_keys.length;
+
+        // need to transform apikey to the obj
+        const apiKeyInfo = await this.getValidAPIKeyInfo(APIKey);
+
+        await collection.updateOne({_id: userID}, {$set: {preferred_key_index: lastIndex}, $push: {api_keys: apiKeyInfo}});
         return 'success';
     }
 

--- a/src/Guildwars/ApiKey/ApiKeyAPI.ts
+++ b/src/Guildwars/ApiKey/ApiKeyAPI.ts
@@ -159,6 +159,12 @@ export default class ApiKeyAPI {
         return ['err-default'];
     }
 
+    /**
+     * Deletes all keys that are in the keysToRemove from the user's api_keys array
+     * @param userID 
+     * @param keysToRemove - cannot be empty
+     * @returns 
+     */
     public removeUserKeysFromDB = async(userID: string, keysToRemove: string[]): Promise<string> => {
         const users = await getCollection('users');
         if(!users) {return 'err-default'}; // Ahhhh
@@ -167,6 +173,23 @@ export default class ApiKeyAPI {
         return `success-${keysToRemove.length}`;   
     }
 
-    // changepreferredAPIKeyToUse
+    /**
+     * 
+     * @param userInfo 
+     * @param index 1-indexed
+     * @returns 
+     */
+    public switchUserPreferredKeyInDB = async(userInfo: UserAPIKeyInfo, index: number): Promise<string> => {
+        const users = await getCollection('users');
+        if(!users) {return 'err-default'}; // Ahhhh
+
+        if(!userInfo.api_keys[index - 1]) {return 'err-wrong-key-index'};
+        if(userInfo.api_keys[index - 1].key_id === userInfo.preferred_api_key) {return 'err-already-preferred'}
+
+        const newPreferredKey = userInfo.api_keys[index - 1].key_id;
+        await users.updateOne({_id: userInfo._id}, {$set: {'preferred_api_key': newPreferredKey}});
+
+        return `success`;    
+    }
 }
 

--- a/src/Guildwars/ApiKey/ApiKeyAPI.ts
+++ b/src/Guildwars/ApiKey/ApiKeyAPI.ts
@@ -191,5 +191,13 @@ export default class ApiKeyAPI {
 
         return `success`;    
     }
+
+    public purgeAllUserDataFromDB = async(userID: string): Promise<string> => {
+        const users = await getCollection('users');
+        if(!users) {return 'err-default'}; // Ahhhh
+        
+        await users.deleteOne({_id: userID});
+        return `success`;
+    }
 }
 

--- a/src/Guildwars/ApiKey/ApiKeyAPI.ts
+++ b/src/Guildwars/ApiKey/ApiKeyAPI.ts
@@ -1,5 +1,8 @@
 import axios from "axios"
 import { Collection, Document } from "mongodb";
+import AccountInfo from "../../Model/Guildwars/AccountInfo";
+import APIKeyInfo from "../../Model/Guildwars/APIKeyInfo";
+import TokenInfo from "../../Model/Guildwars/TokenInfo";
 import UserDB from "../../Model/Guildwars/UserDB";
 import { collectionExists, getCollection, getDb, insertMany, insertOne } from "../../Mongo/Mongo";
 import { GW_API_URL } from "../General/enum/GW_API_URL";
@@ -8,15 +11,67 @@ import { GW_API_URL } from "../General/enum/GW_API_URL";
 export default class ApiKeyAPI {
 
     /**
-     * Returns either [] if the user is not our DB
-     * or an array of one Document if the user is found since _id is unique
-     * 
+     * Returns either the user's Document or null/undefined
     */    
-    public getUserInfoFromDB = async (userID: string) => {
+    public getUserFromDB = async (userID: string) => {
         const collection = await getCollection('users');
         const userInfo = await collection?.findOne({_id: userID});
         return userInfo;
     }
+
+    
+    public getAPIKeyTokenInfo = async(APIKey: string) => {
+        const keyResponse = await axios.get(`${GW_API_URL.TOKENINFO}?access_token=${APIKey}`);
+        return (<TokenInfo> keyResponse.data);
+    }
+
+    public getAccountName = async(APIKey: string) => {
+        const accountResponse = await axios.get(`${GW_API_URL.ACCOUNT}?access_token=${APIKey}`);
+        const accountInfo: AccountInfo = accountResponse.data;
+        return accountInfo.name;
+    }
+
+    /**
+     * Need to check API Keys validity before displaying something
+     */
+    public getAPIKeyInfo = async(APIKey: string, isPreferred: boolean = false) => {
+        const isValid = await this.isAPIKeyValid(APIKey);
+        
+        if (!isValid) {
+           return <APIKeyInfo> {
+                account_name: '?',
+                key_id: APIKey,
+                key_name: 'Invalid API Key',
+                key_permissions: [],
+                is_valid: false,
+                is_preferred: isPreferred
+            }
+        }
+
+        const accountName = await this.getAccountName(APIKey);
+        const keyTokenInfo = await this.getAPIKeyTokenInfo(APIKey);        
+
+        return <APIKeyInfo> {
+            account_name: accountName,
+            key_id: APIKey,
+            key_name: keyTokenInfo.name,
+            key_permissions: keyTokenInfo.permissions,
+            is_valid: isValid,
+            is_preferred: isPreferred
+        }
+    }
+
+    /**
+     * Creates an array of all the juicy APIKey data
+     * assumes user actually exists!
+     */
+    public createAPIKeysInfo = async(userDB: UserDB) => {
+        return await Promise.all(userDB.API_Keys.map( async (key, index) => {
+            const isPreferred = index === userDB.preferredAPIKey;
+            return await this.getAPIKeyInfo(key, isPreferred);
+        }));
+    }
+
 
     /** 
      * Or rather add the default skeleton of an user object
@@ -57,24 +112,24 @@ export default class ApiKeyAPI {
         const collection = await getCollection('users');
         if(!collection) {return 'err-default'}; // Ahhhh
 
-        const userInfo = <UserDB> await this.getUserInfoFromDB(userID);
+        const userDB = <UserDB> await this.getUserFromDB(userID);
         
         // validate key here first
         if (! await this.isAPIKeyValid(APIKey)) {return 'err-invalid-api-key'}
 
         // if the user is not in our DB, add their default skeleton object
-        if (! userInfo){
+        if (! userDB){
             await this.addUserToCollection(userID, collection);
         }
 
         // unless the insert failed, user has to be in the DB
-        const userInfoNew = <UserDB> await this.getUserInfoFromDB(userID);
+        const userDBNew = <UserDB> await this.getUserFromDB(userID);
 
         // check if the new api key is unique
-        if (userInfoNew.API_Keys.includes(APIKey)){return 'err-non-unique-key'}
+        if (userDBNew.API_Keys.includes(APIKey)){return 'err-non-unique-key'}
 
         // Push the new key to the API_Keys array, and set the preferred key to be the one we just pushed
-        const lastIndex = userInfoNew.API_Keys.length;
+        const lastIndex = userDBNew.API_Keys.length;
         await collection.updateOne({_id: userID}, {$set: {preferredAPIKey: lastIndex}, $push: {API_Keys: APIKey}});
         return 'success';
     }

--- a/src/Guildwars/General/enum/GW_API_URL.ts
+++ b/src/Guildwars/General/enum/GW_API_URL.ts
@@ -6,4 +6,5 @@ export enum GW_API_URL {
     PSNA = "https://docs.google.com/spreadsheets/d/1hIw2DAzdD72wPfP-GJ3sNlf4weaJ2L2mMFGJPFb93eE/edit#gid=0&range=A1:F2/gviz/tq?tq=select%20*",
     ITEMS = "https://api.guildwars2.com/v2/items",
     GUILD = "https://api.guildwars2.com/v2/guild/",
+    TOKENINFO = "https://api.guildwars2.com/v2/tokeninfo"
 }

--- a/src/Guildwars/General/enum/GW_API_URL.ts
+++ b/src/Guildwars/General/enum/GW_API_URL.ts
@@ -6,5 +6,6 @@ export enum GW_API_URL {
     PSNA = "https://docs.google.com/spreadsheets/d/1hIw2DAzdD72wPfP-GJ3sNlf4weaJ2L2mMFGJPFb93eE/edit#gid=0&range=A1:F2/gviz/tq?tq=select%20*",
     ITEMS = "https://api.guildwars2.com/v2/items",
     GUILD = "https://api.guildwars2.com/v2/guild/",
-    TOKENINFO = "https://api.guildwars2.com/v2/tokeninfo"
+    TOKENINFO = "https://api.guildwars2.com/v2/tokeninfo",
+    ACCOUNT = "https://api.guildwars2.com/v2/account"
 }

--- a/src/Model/Guildwars/APIKeyInfo.ts
+++ b/src/Model/Guildwars/APIKeyInfo.ts
@@ -4,5 +4,4 @@ export default interface APIKeyInfo {
     key_name: string;
     key_permissions: string[];
     is_valid: boolean;
-    is_preferred: boolean;
 }

--- a/src/Model/Guildwars/APIKeyInfo.ts
+++ b/src/Model/Guildwars/APIKeyInfo.ts
@@ -1,0 +1,8 @@
+export default interface APIKeyInfo {
+    account_name: string;
+    key_id: string;
+    key_name: string;
+    key_permissions: string[];
+    is_valid: boolean;
+    is_preferred: boolean;
+}

--- a/src/Model/Guildwars/AccountInfo.ts
+++ b/src/Model/Guildwars/AccountInfo.ts
@@ -1,0 +1,10 @@
+export default interface AccountInfo {
+    id: string;
+    age: number;
+    name: string;
+    world: number;
+    guilds: string[];
+    created: string;
+    access: string[];
+    commander: boolean;
+}

--- a/src/Model/Guildwars/TokenInfo.ts
+++ b/src/Model/Guildwars/TokenInfo.ts
@@ -1,0 +1,5 @@
+export default interface TokenInfo {
+    id: string;
+    name: string;
+    permissions: string[];
+}

--- a/src/Model/Guildwars/UserAPIKeyInfo.ts
+++ b/src/Model/Guildwars/UserAPIKeyInfo.ts
@@ -1,0 +1,7 @@
+import APIKeyInfo from "./APIKeyInfo";
+
+export default interface UserAPIKeyInfo {
+    _id: string;
+    api_keys: APIKeyInfo[];
+    preferred_key_index: number;
+}

--- a/src/Model/Guildwars/UserAPIKeyInfo.ts
+++ b/src/Model/Guildwars/UserAPIKeyInfo.ts
@@ -2,6 +2,6 @@ import APIKeyInfo from "./APIKeyInfo";
 
 export default interface UserAPIKeyInfo {
     _id: string;
+    preferred_api_key: string;
     api_keys: APIKeyInfo[];
-    preferred_key_index: number;
 }

--- a/src/Model/Guildwars/UserDB.ts
+++ b/src/Model/Guildwars/UserDB.ts
@@ -1,4 +1,3 @@
-
 export default interface UserDB {
     _id: string; // discord User ID
     API_Keys: string[];

--- a/src/Model/Guildwars/UserDB.ts
+++ b/src/Model/Guildwars/UserDB.ts
@@ -1,0 +1,7 @@
+
+export default interface UserDB {
+    _id: string; // discord User ID
+    API_Keys: string[];
+    preferredAPIKey: number;
+    // possibly kp.me key in the future
+}

--- a/src/Model/Guildwars/UserDB.ts
+++ b/src/Model/Guildwars/UserDB.ts
@@ -1,6 +1,0 @@
-export default interface UserDB {
-    _id: string; // discord User ID
-    API_Keys: string[];
-    preferredAPIKey: number;
-    // possibly kp.me key in the future
-}

--- a/src/Util/util.ts
+++ b/src/Util/util.ts
@@ -94,3 +94,15 @@ export const objectWithoutKey = <T>(object:Record<string, T>, key:string) => {
 export const differenceSet = <T>(setA: Set<T>, setB: Set<T>) => {
     return new Set([...setA].filter( element => !setB.has(element)));
 }
+
+/**
+ * From https://github.com/sindresorhus/escape-string-regexp
+ * Will come in handy for the names of API keys, since those are unescaped
+ */ 
+export function escapeStringRegexp(unescapedString: string) {
+	// Escape characters with special meaning either inside or outside character sets.
+	// Use a simple backslash escape when it’s always valid, and a `\xnn` escape when the simpler form would be disallowed by Unicode patterns’ stricter grammar.
+	return unescapedString
+		.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+		.replace(/-/g, '\\x2d');
+}


### PR DESCRIPTION
### Handles all of the storage, new additions, removals, and changes to GW2 API Keys which the user might want to do. While the commands can be sent from anywhere, the bot always responds in PMs.
Adds multiple /api-key discord commands:

1. **show** - Displays All API Keys we have stored with the command-caller's discord id. Also validates the keys, so the user can see which keys are valid at a given time (does not as of now change the DB record).
2. **add** - Adds a single API key to our DB. If the user's document doesn't exist, create it, and add the new API key to it. Validates if the key is actually valid before adding and if it has not already been added to this user.
3. **remove all** - Removes all API Keys from the user's document. Other fields we might possibly have in the future, will be left intact.
4. **remove non-preferred** - Removes all API Keys that are not preferred, i.e. ones the user doesn't want to use. If there aren't any such keys it will let the user know.
5. **remove by-index** - Removes single API Key specified by the user with index (1-based indexing). Will not allow the user to delete the preferred API Key ( should use switch first, or remove all).
6. **switch-preferred** - Switches user's preferred key, i.e. the one we would use for all the different account-based commands. Can't switch to a key that's already preferred. 1-based indexing as well.
7. **purge-all-data** - Deletes the whole user's document with all its data. Also, asks the user for confirmation.